### PR TITLE
display-github-context: add macos-13 runners

### DIFF
--- a/.github/workflows/display-github-context.yml
+++ b/.github/workflows/display-github-context.yml
@@ -18,6 +18,8 @@ jobs:
           - ubuntu-22.04
           - macos-11
           - macos-12
+          - macos-13
+          - macos-13-xl
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/display-github-context.yml
+++ b/.github/workflows/display-github-context.yml
@@ -19,7 +19,8 @@ jobs:
           - macos-11
           - macos-12
           - macos-13
-          - macos-13-xl
+          # custom runner
+          # - macos-13-xl
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
changelog, https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/