### PR TITLE
renovate: add explicit commitMessagePrefix

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
     'config:recommended',
     'schedule:daily',
   ],
+  commitMessagePrefix: 'chore(deps):',
   commitMessageSuffix: ' in {{packageFile}}',
   dependencyDashboard: true,
   automerge: true,


### PR DESCRIPTION
The `config:recommended` preset recently stopped including `chore(deps):` as
the default commit message prefix.

Same fix as chenrui333/homebrew-tap#5873.
