### PR TITLE
chore: switch renovate to config:best-practices

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,18 +1,20 @@
 {
   extends: [
-    'config:recommended',
+    'config:best-practices',
     'schedule:daily',
   ],
   commitMessagePrefix: 'chore(deps):',
   commitMessageSuffix: ' in {{packageFile}}',
-  dependencyDashboard: true,
   automerge: true,
+  automergeType: 'pr',
   automergeStrategy: 'rebase',
+  platformAutomerge: false,
+  minimumReleaseAge: '2 days',
+  internalChecksFilter: 'strict',
   baseBranches: [
     'main',
     '/^release-.*/',
   ],
-  platformAutomerge: true,
   labels: [
     'dependencies',
   ],


### PR DESCRIPTION
Align Renovate config with best practices:

- `config:recommended` → `config:best-practices` (enables SHA pinning for GitHub Actions via `helpers:pinGitHubActionDigests`)
- Add `minimumReleaseAge: 2 days` soak time
- Add `internalChecksFilter: strict`
- Set `platformAutomerge: false`, `automergeType: pr` (Renovate-managed merges)
- Drop redundant `dependencyDashboard: true` (already in `config:best-practices`)

Renovate will open follow-up PRs to pin existing deps to SHA digests.