### PR TITLE
chore(deps): exempt digest updates from minimum age

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,15 @@
   platformAutomerge: false,
   minimumReleaseAge: '2 days',
   internalChecksFilter: 'strict',
+  packageRules: [
+    {
+      matchUpdateTypes: [
+        'digest',
+        'pinDigest',
+      ],
+      minimumReleaseAge: null,
+    },
+  ],
   baseBranchPatterns: [
     'main',
     '/^release-.*/',


### PR DESCRIPTION
Summary:
- Exempt digest and pinDigest updates from the global Renovate minimum release age.
- Keep the 2-day stability gate for normal version updates.

References:
- https://docs.renovatebot.com/key-concepts/minimum-release-age/
- https://docs.renovatebot.com/configuration-options/#minimumreleaseage
