### PR TITLE
fix(security): make credential and event experiments safe

### DIFF
--- a/.github/workflows/check-helm.yml
+++ b/.github/workflows/check-helm.yml
@@ -1,9 +1,9 @@
-name: display-github-context
+name: check-helm
 
 on:
   pull_request:
     paths:
-      - '.github/workflows/display-github-context.yml'
+      - '.github/workflows/check-helm.yml'
 
 jobs:
   all_jobs:
@@ -43,14 +43,18 @@ jobs:
           if command -v helm >/dev/null 2>&1; then
             HELM_BIN="$(command -v helm)"
             HELM_VER="$(helm version --short 2>/dev/null || true)"
-            echo "helm_found=true"            >> "$GITHUB_OUTPUT"
-            echo "helm_path=${HELM_BIN}"      >> "$GITHUB_OUTPUT"
-            echo "helm_version=${HELM_VER}"   >> "$GITHUB_OUTPUT"
+            {
+              echo "helm_found=true"
+              echo "helm_path=${HELM_BIN}"
+              echo "helm_version=${HELM_VER}"
+            } >> "$GITHUB_OUTPUT"
             echo "Found Helm at ${HELM_BIN}: ${HELM_VER}"
           else
-            echo "helm_found=false"           >> "$GITHUB_OUTPUT"
-            echo "helm_path="                 >> "$GITHUB_OUTPUT"
-            echo "helm_version="              >> "$GITHUB_OUTPUT"
+            {
+              echo "helm_found=false"
+              echo "helm_path="
+              echo "helm_version="
+            } >> "$GITHUB_OUTPUT"
             echo "Helm not found on PATH"
           fi
 
@@ -76,8 +80,13 @@ jobs:
 
       # --- Update the PR comment to include Helm info ---
       - name: Post runner info as PR comment
-        if: ${{ github.event_name == 'pull_request' }}
+        # Fork PR tokens cannot write comments; runner diagnostics still run.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          HELM_FOUND: ${{ steps.helm_check_win.outputs.helm_found || steps.helm_check_unix.outputs.helm_found }}
+          HELM_PATH: ${{ steps.helm_check_win.outputs.helm_path || steps.helm_check_unix.outputs.helm_path }}
+          HELM_VERSION: ${{ steps.helm_check_win.outputs.helm_version || steps.helm_check_unix.outputs.helm_version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -86,13 +95,9 @@ jobs:
               return;
             }
 
-            // Pick the right step outputs based on OS
-            const isWin = process.env.RUNNER_OS === 'Windows';
-            const step = isWin ? '${{ steps.helm_check_win.outputs.helm_found }}' : '${{ steps.helm_check_unix.outputs.helm_found }}';
-
-            const helmFound   = isWin ? '${{ steps.helm_check_win.outputs.helm_found }}'   : '${{ steps.helm_check_unix.outputs.helm_found }}';
-            const helmPath    = isWin ? '${{ steps.helm_check_win.outputs.helm_path }}'    : '${{ steps.helm_check_unix.outputs.helm_path }}';
-            const helmVersion = isWin ? '${{ steps.helm_check_win.outputs.helm_version }}' : '${{ steps.helm_check_unix.outputs.helm_version }}';
+            const helmFound = process.env.HELM_FOUND;
+            const helmPath = process.env.HELM_PATH;
+            const helmVersion = process.env.HELM_VERSION;
 
             const helmLines = helmFound === 'true'
               ? [`**Helm**: ${helmVersion}`, `**Helm Path**: ${helmPath}`]

--- a/.github/workflows/credentials.yml
+++ b/.github/workflows/credentials.yml
@@ -9,9 +9,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
-      - name: Setup upterm session
-        uses: owenthereal/action-upterm@47652056242288ccbebd30f836e9885d09a75365 # v1
       - name: Write into file
         id: write_file
         uses: timheuer/base64-to-file@dfa5a5dd38803cb4f5c3a081eeb28e8362d43e9c # v2.0
@@ -19,7 +18,20 @@ jobs:
           fileName: 'myTemporaryFile.txt'
           encodedString: ${{ secrets.AWS_CREDENTIALS_FILE_BASE64 }}
 
-      - name: Use the output
+      # Decoded secrets are not automatically masked. Verify without logging content.
+      - name: Verify credential file
+        env:
+          CREDENTIAL_FILE: ${{ steps.write_file.outputs.filePath }}
         run: |
-          ls ${{ steps.write_file.outputs.filePath }}
-          cat ${{ steps.write_file.outputs.filePath }}
+          chmod 600 "$CREDENTIAL_FILE"
+          test -s "$CREDENTIAL_FILE"
+          echo "Credential file decoded successfully"
+
+      - name: Remove credential file
+        if: always()
+        env:
+          CREDENTIAL_FILE: ${{ steps.write_file.outputs.filePath }}
+        run: |
+          if [[ -n "$CREDENTIAL_FILE" ]]; then
+            rm -f -- "$CREDENTIAL_FILE"
+          fi

--- a/.github/workflows/delete-event.yml
+++ b/.github/workflows/delete-event.yml
@@ -16,7 +16,10 @@ jobs:
           persist-credentials: false
 
       - name: run build
+        env:
+          DELETED_REF: ${{ github.event.ref }}
+          DELETED_REF_TYPE: ${{ github.event.ref_type }}
         run: |
-          echo "GITHUB_SHA is ${{ github.sha }}"
-          echo "GITHUB_REF is ${{ github.ref }}"
-          echo "${{ github.event.ref }} - ${{ github.event.ref_type }}"
+          printf 'GITHUB_SHA is %s\n' "$GITHUB_SHA"
+          printf 'GITHUB_REF is %s\n' "$GITHUB_REF"
+          printf '%s - %s\n' "$DELETED_REF" "$DELETED_REF_TYPE"

--- a/.github/workflows/display-github-context.yml
+++ b/.github/workflows/display-github-context.yml
@@ -38,24 +38,25 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu-') || startsWith(matrix.os, 'macos-')
         shell: bash
         env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
+          EVENT_CONTEXT: ${{ toJSON(github.event) }}
         run: |
           echo "RUNNER_OS: $RUNNER_OS"
           echo "RUNNER_ARCH: $RUNNER_ARCH"
-          printf 'GITHUB_CONTEXT: %s\n' "$GITHUB_CONTEXT"
+          printf 'EVENT_CONTEXT: %s\n' "$EVENT_CONTEXT"
 
       - name: Show runner info (Windows)
         if: startsWith(matrix.os, 'windows-')
         shell: pwsh
         env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
+          EVENT_CONTEXT: ${{ toJSON(github.event) }}
         run: |
           echo "RUNNER_OS: $env:RUNNER_OS"
           echo "RUNNER_ARCH: $env:RUNNER_ARCH"
-          echo "GITHUB_CONTEXT: $env:GITHUB_CONTEXT"
+          echo "EVENT_CONTEXT: $env:EVENT_CONTEXT"
 
       - name: Post runner info as PR comment
-        if: ${{ github.event_name == 'pull_request' }}
+        # Fork PR tokens cannot write comments; runner diagnostics still run.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -5,7 +5,7 @@ on:
     types: ["trigger-event"]
 
 # how to test this workflow
-# GITHUB_TOKEN=xxx ./scripts/repository-dispatch-trigger.sh
+# gh auth login, then ./scripts/repository-dispatch-trigger.sh
 
 # run log result
 # https://github.com/chenrui333/github-action-test/actions/runs/161112535
@@ -26,14 +26,16 @@ jobs:
 
       - name: show context
         run: |
-          echo "github sha is ${{ github.sha }}"
-          echo "github.event is ${{ toJson(github.event) }}"
-          echo "github.event_name is ${{ github.event_name }}"
+          printf 'github sha is %s\n' "$GITHUB_SHA"
+          cat "$GITHUB_EVENT_PATH"
+          printf 'github.event_name is %s\n' "$GITHUB_EVENT_NAME"
       - name: run build
         if: github.event_name == 'repository_dispatch'
+        env:
+          INTEGRATION: ${{ github.event.client_payload.integration }}
         run: |
-          echo "id is $ID"
-          echo "integration is ${{ github.event.client_payload.integration }}"
+          printf 'id is %s\n' "$ID"
+          printf 'integration is %s\n' "$INTEGRATION"
 
   show-id:
     runs-on: ubuntu-24.04

--- a/.github/workflows/workflow-dispatch.yml
+++ b/.github/workflows/workflow-dispatch.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: |
-          echo "Job time range arg: ${{ github.event.inputs.time_window }}"
-          echo "Job run manually?: ${{ github.event.inputs.manual }}"
+      - env:
+          TIME_WINDOW: ${{ inputs.time_window }}
+          MANUAL: ${{ inputs.manual }}
+        run: |
+          printf 'Job time range arg: %s\n' "$TIME_WINDOW"
+          printf 'Job run manually?: %s\n' "$MANUAL"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,20 +1,5 @@
 rules:
   dangerous-triggers:
     ignore:
+      # Closed same-repository PRs only; no checkout or execution of PR code.
       - clean-up-closed-prs.yml:3
-  template-injection:
-    ignore:
-      - check-helm.yml:91
-      - check-helm.yml:93
-      - check-helm.yml:94
-      - check-helm.yml:95
-      - credentials.yml:22
-      - delete-event.yml:18
-      - display-github-context.yml:34
-      - display-github-context.yml:42
-      - repository-dispatch.yml:27
-      - repository-dispatch.yml:32
-      - workflow-dispatch.yml:25
-  unpinned-uses:
-    ignore:
-      - credentials.yml:14

--- a/scripts/repository-dispatch-trigger.sh
+++ b/scripts/repository-dispatch-trigger.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
+set -euo pipefail
 
-set -e
+# Authenticate with `gh auth login` or an existing GH_TOKEN/GITHUB_TOKEN environment.
+# No token is passed in process arguments. The API command fails on HTTP errors.
+if [[ "${1:-}" == "--help" ]]; then
+  echo "Usage: repository-dispatch-trigger.sh [--dry-run]"
+  exit 0
+fi
+if [[ $# -gt 1 || ( $# -eq 1 && "$1" != "--dry-run" ) ]]; then
+  echo "Usage: repository-dispatch-trigger.sh [--dry-run]" >&2
+  exit 2
+fi
 
-main() {
-  local id="962368b5c27b7ec5ecfcb4ed8f8c57adb52a8442"
-  curl -X POST -u "chenrui333:${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github.everest-preview+json"  \
-    -H "Content-Type: application/json" \
-    https://api.github.com/repos/chenrui333/github-action-test/dispatches \
-    --data "{\"event_type\":\"trigger-event\",\"client_payload\":{\"id\":\"$id\", \"unit\":false,\"integration\":true}}"
-}
+payload='{"event_type":"trigger-event","client_payload":{"id":"962368b5c27b7ec5ecfcb4ed8f8c57adb52a8442","unit":false,"integration":true}}'
+if [[ "${1:-}" == "--dry-run" ]]; then
+  printf '%s\n' "$payload"
+  exit 0
+fi
 
-main "$@"
+printf '%s\n' "$payload" | gh api --method POST \
+  -H 'Accept: application/vnd.github+json' \
+  repos/chenrui333/github-action-test/dispatches --input -


### PR DESCRIPTION
## Summary
Keep credential decoding and event diagnostics usable without printing decoded credentials or evaluating payloads as shell/JavaScript source. Remove the debug shell from the credential-bearing job, clean up its temporary file, and replace broad GitHub context logging with event context.

Fix the Helm diagnostic's copied workflow name/path filter and pass its outputs through environment variables. Fork PRs retain diagnostics but skip comments their tokens cannot write. Remove resolved zizmor exceptions; retain only the closed-PR cleanup exception.
