### PR TITLE
fix(container): verify tools and publish supported architectures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,10 @@
 name: docker
 
 on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .github/workflows/docker.yml
   push:
     branches:
       - main
@@ -14,6 +18,7 @@ permissions:
 jobs:
   docker:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -23,7 +28,7 @@ jobs:
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
         with:
           image: tonistiigi/binfmt:latest
-          platforms: arm64,arm
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -31,24 +36,26 @@ jobs:
           cache-binary: false
 
       - name: Login to DockerHub
+        if: github.event_name == 'push'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: 'chenrui'
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
+        if: github.event_name == 'push'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GH_REGISTRY_TOKEN }}
 
-      - name: Build and push
+      - name: Build image (publish only on main push)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
           tags: |
             chenrui/github-action-test:latest
             chenrui/github-action-test:${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,14 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write # publish the release image to GHCR
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -21,7 +24,7 @@ jobs:
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
         with:
           image: tonistiigi/binfmt:latest
-          platforms: arm64,arm
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -39,7 +42,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,29 +4,43 @@ FROM golang:1.27@sha256:512690a5660563b57d37ecc31129e7f136e831db2aed24a1dbeb8ad7
 # renovate: release=stable depName=unzip
 ARG UNZIP_VERSION=6.0-29
 RUN apt-get update && \
-    apt-get install -y unzip=${UNZIP_VERSION}
+    apt-get install -y --no-install-recommends unzip=${UNZIP_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+# Only amd64 and arm64 have binary releases for every bundled tool.
+ARG TARGETARCH
 
 # Install Terraform
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
 ARG TERRAFORM_VERSION=1.11.1
-RUN case $(uname -m) in x86_64|amd64) ARCH="amd64" ;; aarch64|arm64|armv7l) ARCH="arm64" ;; esac && \
-    wget -nv -O terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
+RUN case "$TARGETARCH" in amd64|arm64) ARCH="$TARGETARCH" ;; *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; esac && \
+    curl --retry 3 --retry-all-errors --connect-timeout 20 --max-time 300 -fsSLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip && \
+    curl --retry 3 --retry-all-errors --connect-timeout 20 --max-time 300 -fsSLo terraform_SHA256SUMS https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
+    awk -v file="terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip" '$2 == file {print $1 "  terraform.zip"}' terraform_SHA256SUMS > terraform.sha256 && \
+    test -s terraform.sha256 && sha256sum -c terraform.sha256 && \
     mkdir -p /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \
     unzip terraform.zip -d /usr/local/bin/tf/versions/${TERRAFORM_VERSION} && \
     ln -s /usr/local/bin/tf/versions/${TERRAFORM_VERSION}/terraform /usr/local/bin/terraform && \
-    rm terraform.zip
+    rm terraform.zip terraform_SHA256SUMS terraform.sha256
 
 # Install conftest
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
 ARG CONFTEST_VERSION=0.58.0
-RUN case $(uname -m) in x86_64|amd64) ARCH="x86_64" ;; aarch64|arm64|armv7l) ARCH="arm64" ;; esac && \
-    curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
-    curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/checksums.txt && \
-    sed -n "/conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz/p" checksums.txt | sha256sum -c && \
+RUN case "$TARGETARCH" in amd64) ARCH="x86_64" ;; arm64) ARCH="arm64" ;; *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; esac && \
+    curl --retry 3 --retry-all-errors --connect-timeout 20 --max-time 300 -fLOsS https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
+    curl --retry 3 --retry-all-errors --connect-timeout 20 --max-time 300 -fLOsS https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/checksums.txt && \
+    awk -v file="conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz" '$2 == file {print}' checksums.txt > conftest.sha256 && \
+    test -s conftest.sha256 && sha256sum -c conftest.sha256 && \
     mkdir -p /usr/local/bin/cft/versions/${CONFTEST_VERSION} && \
     tar -C  /usr/local/bin/cft/versions/${CONFTEST_VERSION} -xzf conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
     ln -s /usr/local/bin/cft/versions/${CONFTEST_VERSION}/conftest /usr/local/bin/conftest${CONFTEST_VERSION} && \
     rm conftest_${CONFTEST_VERSION}_Linux_${ARCH}.tar.gz && \
-    rm checksums.txt
+    rm checksums.txt conftest.sha256
 
-RUN go install golang.org/x/tools/cmd/goimports@latest
+# renovate: datasource=github-tags depName=golang/tools
+ARG GOIMPORTS_VERSION=0.49.0
+RUN go install golang.org/x/tools/cmd/goimports@v${GOIMPORTS_VERSION}
+
+# A successful cross-platform build must also execute the bundled binaries.
+RUN terraform version && conftest${CONFTEST_VERSION} --version && \
+    printf 'package main\nfunc main() {}\n' | goimports


### PR DESCRIPTION
## Summary
Stop publishing ARMv7 images containing ARM64 binaries: Conftest has no ARMv7 release at the pinned version. Select supported architectures through TARGETARCH and execute bundled tools during the build.

Verify Terraform and Conftest checksum entries, bound/retry downloads, clear apt lists, and pin goimports to the version resolved by the baseline build. Add read-only PR builds; registry login and publication remain restricted to main pushes. Scope release package writes to the publishing job.

## References
- [Conftest 0.58.0 assets](https://github.com/open-policy-agent/conftest/releases/tag/v0.58.0)
- [Docker target architecture arguments](https://docs.docker.com/build/building/variables/#multi-platform-build-arguments)
