### PR TITLE
fix(renovate): match merge policy and track Docker ARG versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,7 @@
   commitMessageSuffix: ' in {{packageFile}}',
   automerge: true,
   automergeType: 'pr',
-  automergeStrategy: 'rebase',
+  automergeStrategy: 'squash',
   platformAutomerge: false,
   minimumReleaseAge: '2 days',
   internalChecksFilter: 'strict',
@@ -41,10 +41,10 @@
         '/(^|/)Dockerfile\\.[^/]*$/',
       ],
       matchStrings: [
-        'renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=(?<currentValue>.*)\\s',
+        'renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(?:ARG|ENV) .*?_VERSION=(?<currentValue>.*)\\s',
       ],
       versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
-      extractVersionTemplate: '^v(?<version>\\d+\\.\\d+\\.\\d+)',
+      extractVersionTemplate: '^v?(?<version>\\d+\\.\\d+\\.\\d+)',
     },
     {
       customType: 'regex',


### PR DESCRIPTION
## Summary
Use squash automerge to match the repository's only enabled merge strategy. Extend Docker version extraction to ARG as well as ENV so Terraform and Conftest are actually detected, and accept upstream version tags with or without a leading v.

## References
- #35 currently omits these Docker ARG dependencies.
- [Renovate custom regex manager](https://docs.renovatebot.com/modules/manager/regex/)
